### PR TITLE
Upgrade Gradle to version 8.2.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This fixes the following error when using Gradle 7.6.x together with Kotlin 1.9:

> Module was compiled with an incompatible version of Kotlin. The binary version
> of its metadata is 1.9.0, expected version is 1.7.1.